### PR TITLE
Fix vocab IRI for SMRR  to match BDR usage. Fix erroneous /bdr-proj/ usages for /bdr-pr/proj/

### DIFF
--- a/spec/03-preamble.adoc
+++ b/spec/03-preamble.adoc
@@ -26,7 +26,7 @@ Namespaces are used in shortened form in documents and data by assigning them a 
 |`abis:` | `https://linked.data.gov.au/def/abis/` | ABIS namespace
 |`dr:` | `https://linked.data.gov.au/def/bdr-pr/dr/` | <<#annex-b, BDR Data Release Model>> namespace
 |`bdr:` | `https://linked.data.gov.au/dataset/bdr/` | BDR Dataset Namespace
-|`proj:` | `https://linked.data.gov.au/def/bdr-proj/` | <<#annex-b, BDR Projects Model>> namespace
+|`proj:` | `https://linked.data.gov.au/def/bdr-pr/proj/` | <<#annex-b, BDR Projects Model>> namespace
 |`dcat:`| `http://www.w3.org/ns/dcat#` | <<DCAT, Data Catalogue Vocabulary>> namespace
 |`ex:` | `+http://example.com/+` | Generic examples namespace - _does not resolve_
 |`geo:` | `http://www.opengis.net/ont/geosparql#` | <<GSP, GeoSPARQL Ontology>> namespace
@@ -34,7 +34,7 @@ Namespaces are used in shortened form in documents and data by assigning them a 
 |`rdfs:` | `http://www.w3.org/2000/01/rdf-schema#` | <<RDFSSPEC, RDF Schema ontology>> namespace
 |`sosa:` | `http://www.w3.org/ns/sosa/` | <<SOSA, Sensor, Observation, Sample, and Actuator (SOSA) ontology>> namespace
 |`schema:` | `https://schema.org/` | <<SDO, schema.org>> namespace
-|`https://linked.data.gov.au/def/bdr-proj/:` | `https://linked.data.gov.au/def/bdr-pr/sm/` | <<#annex-c, BDR Submission Manifest Model>> namespace
+|`sm:` | `https://linked.data.gov.au/def/bdr-pr/sm/` | <<#annex-c, BDR Submission Manifest Model>> namespace
 |`skos:` | `http://www.w3.org/2004/02/skos/core#` | <<SKOS, Simple Knowledge Organization System (SKOS) ontology>> namespace
 |`tern:` | `https://w3id.org/tern/ontologies/tern/` | <<TERNOntology, TERN Ontology>> namespace
 |`time:` | `http://www.w3.org/2006/time#` | <<TIME, Time Ontology>> in OWL namespace

--- a/spec/06-models.adoc
+++ b/spec/06-models.adoc
@@ -51,11 +51,12 @@ The above information, if in a file called `data.ttl`, could be packaged and sen
 
 [source, turtle]
 ----
+@prefix smrr: <https://linked.data.gov.au/dataset/bdr/smrr/> .
 []
     a bdrsm:SubmissionManifest ;
     prof:hasResource [
         prof:hasArtifact "data.ttl" ;
-        prof:hasRole https://linked.data.gov.au/def/bdr-proj/rr:SufficientForValidation ;
+        prof:hasRole smrr:SufficientForValidation ;
     ] ;
 .
 ----

--- a/spec/50_annex_a.adoc
+++ b/spec/50_annex_a.adoc
@@ -25,7 +25,7 @@ Also, as per PROV, some information about an `Entity` (data), produced by an `Ac
 |*https://schema.org/dateModified[Modified Date]* | 2023-04-30
 |*https://schema.org/dateIssued[Issued Date]* | 2025-04-30
 |*https://schema.org/version[Version]* | 2.1
-|*https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Ontology_IRI_and_Version_IRI[Version IRI]* | https://linked.data.gov.au/def/bdr-proj/2.0[proj:2.0]
+|*https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Ontology_IRI_and_Version_IRI[Version IRI]* | https://linked.data.gov.au/def/bdr-pr/proj/2.0[proj:2.0]
 |*https://www.w3.org/TR/skos-reference/#historyNote[Version History]*| *2.1* - 2025 April - simplification to use schema.org Project
 
 2.0 - 2023 Dec - First release (v2.0 to match ABIS)
@@ -44,7 +44,7 @@ Issue tracking for this profile is managed online at https://github.com/dcceew-b
 * RDF schema:
 ** https://linked.data.gov.au/def/bdr-pr/proj.ttl
 * <<SHACL, SHACL>> validation file:
-** https://linked.data.gov.au/def/bdr-proj/validator.ttl
+** https://linked.data.gov.au/def/bdr-pr/proj/validator.ttl
 
 === A.3 Classes
 

--- a/spec/52_annex_c.adoc
+++ b/spec/52_annex_c.adoc
@@ -36,8 +36,8 @@ Issue tracking for this profile is managed online at https://github.com/dcceew-b
 ** https://linked.data.gov.au/def/bdr-pr/sm.ttl
 * <<SHACL, SHACL>> validation file:
 ** https://linked.data.gov.au/def/bdr-pr/sm/validator.ttl
-* Submission Manifest Model Resource Roles vocabulary:
-** https://linked.data.gov.au/def/bdr-pr/smrr
+* Submission Manifest Model Resource Roles collection:
+** https://linked.data.gov.au/dataset/bdr/smrr
 ** RDF file: https://linked.data.gov.au/def/bdr-pr/smrr.ttl
 
 === C.3 Classes
@@ -152,7 +152,7 @@ Predicates defined elsewhere:
 | https://www.w3.org/TR/skos-reference/#definition[Definition] | A description of a resource that defines an aspect - a particular part, feature or role - of a Profile
 | https://www.w3.org/TR/skos-reference/#definition[History Note] | Defined in <<PROF, PROF>> and reused directly in this model
 | https://www.w3.org/TR/rdf12-schema/#ch_domain[Domain] | <<prof:ResourceDescriptor, Resource Descriptor>>
-| https://www.w3.org/TR/skos-reference/#scopeNote[Scope Note] | Must be used to indicate a role from the https://linked.data.gov.au/def/bdr-pr/smrr[Submission Manifest Model Resource Roles Vocabulary]
+| https://www.w3.org/TR/skos-reference/#scopeNote[Scope Note] | Must be used to indicate a role from the https://linked.data.gov.au/dataset/bdr/smrr[Submission Manifest Model Resource Roles Vocabulary]
 | https://www.w3.org/TR/skos-reference/#example[Example] | _See the example for <<sm:SubmissionManifest, Submission Manifest>>_
 |===
 
@@ -169,7 +169,7 @@ Predicates defined elsewhere:
 | https://www.w3.org/TR/skos-reference/#definition[Definition] | is in scheme
 | https://www.w3.org/TR/skos-reference/#definition[History Note] | Defined in <<SKOS, SKOS>> and reused directly in this model
 | https://www.w3.org/TR/rdf12-schema/#ch_domain[Domain] | <<prof:ResourceDescriptor, Resource Descriptor>>
-| https://www.w3.org/TR/skos-reference/#scopeNote[Scope Note] | Must be used to indicate that a role used as the value for the <<prof:hasRole, has role>> predicate is within the https://linked.data.gov.au/def/bdr-pr/smrr[Submission Manifest Model Resource Roles Vocabulary]
+| https://www.w3.org/TR/skos-reference/#scopeNote[Scope Note] | Must be used to indicate that a role used as the value for the <<prof:hasRole, has role>> predicate is within the https://linked.data.gov.au/dataset/bdr/smrr[Submission Manifest Model Resource Roles Vocabulary]
 | https://www.w3.org/TR/skos-reference/#example[Example] | _See the example for <<sm:SubmissionManifest, Submission Manifest>>_
 |===
 
@@ -183,7 +183,7 @@ This validator only validates manifest content, not the content of the data that
 
 ==== BDR Submission Manifest Resource Roles
 
-This model depends on the https://linked.data.gov.au/def/bdr-pr/smrr[Submission Manifest Model Resource Roles Vocabulary] which is linked to in the <<C.2 Supporting Assets, C.2 Supporting Assets>> section above.
+This model depends on the https://linked.data.gov.au/dataset/bdr/smrr[Submission Manifest Model Resource Roles Vocabulary] which is linked to in the <<C.2 Supporting Assets, C.2 Supporting Assets>> section above.
 
 Concepts from this vocabulary MUST be used as values for the <<prof:hasRole, has role>> predicate.
 

--- a/spec/examples/annex-a/full.ttl
+++ b/spec/examples/annex-a/full.ttl
@@ -1,6 +1,6 @@
 PREFIX ex: <http://example.com/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX proj: <https://linked.data.gov.au/def/bdr-proj/>
+PREFIX proj: <https://linked.data.gov.au/def/bdr-pr/proj/>
 PREFIX schema: <https://schema.org/>
 PREFIX time: <http://www.w3.org/2006/time#>
 

--- a/spec/examples/annex-c/gaia-archives/submission.ttl
+++ b/spec/examples/annex-c/gaia-archives/submission.ttl
@@ -1,7 +1,7 @@
 PREFIX prof: <http://www.w3.org/ns/dx/prof/>
 PREFIX schema: <https://schema.org/>
-PREFIX sm: <https://linked.data.gov.au/def/bdr-proj/sm/>
-PREFIX smrr: <https://linked.data.gov.au/def/bdr-proj/smrr/>
+PREFIX sm: <https://linked.data.gov.au/def/bdr-pr/sm/>
+PREFIX smrr: <https://linked.data.gov.au/dataset/bdr/smrr/>
 
 []
     a smrr:SubmissionManifest ;

--- a/spec/examples/annex-c/monitor-multi/submission.ttl
+++ b/spec/examples/annex-c/monitor-multi/submission.ttl
@@ -1,7 +1,7 @@
 PREFIX prof: <http://www.w3.org/ns/dx/prof/>
 PREFIX schema: <https://schema.org/>
-PREFIX sm: <https://linked.data.gov.au/def/bdr-proj/sm/>
-PREFIX smrr: <https://linked.data.gov.au/def/bdr-proj/smrr/>
+PREFIX sm: <https://linked.data.gov.au/def/bdr-pr/sm/>
+PREFIX smrr: <https://linked.data.gov.au/dataset/bdr/smrr/>
 
 []
     a sm:SubmissionManifest ;

--- a/spec/examples/annex-c/monitor-simple/submission.ttl
+++ b/spec/examples/annex-c/monitor-simple/submission.ttl
@@ -1,7 +1,7 @@
 PREFIX prof: <http://www.w3.org/ns/dx/prof/>
 PREFIX schema: <https://schema.org/>
-PREFIX sm: <https://linked.data.gov.au/def/bdr-proj/sm/>
-PREFIX smrr: <https://linked.data.gov.au/def/bdr-proj/smrr/>
+PREFIX sm: <https://linked.data.gov.au/def/bdr-pr/sm/>
+PREFIX smrr: <https://linked.data.gov.au/dataset/bdr/smrr/>
 
 []
     a sm:SubmissionManifest ;

--- a/spec/examples/annex-c/submission-classes.ttl
+++ b/spec/examples/annex-c/submission-classes.ttl
@@ -1,6 +1,6 @@
 PREFIX prof: <http://www.w3.org/ns/dx/prof/>
-PREFIX sm: <https://linked.data.gov.au/def/bdr-proj/sm/>
-PREFIX smrr: <https://linked.data.gov.au/def/bdr-proj/smrr/>
+PREFIX sm: <https://linked.data.gov.au/def/bdr-pr/sm/>
+PREFIX smrr: <https://linked.data.gov.au/dataset/bdr/smrr/>
 
 []
     a sm:SubmissionManifest ;

--- a/spec/examples/annex-c/submission-minimal.ttl
+++ b/spec/examples/annex-c/submission-minimal.ttl
@@ -1,6 +1,6 @@
 PREFIX prof: <http://www.w3.org/ns/dx/prof/>
-PREFIX sm: <https://linked.data.gov.au/def/bdr-proj/sm/>
-PREFIX smrr: <https://linked.data.gov.au/def/bdr-proj/smrr/>
+PREFIX sm: <https://linked.data.gov.au/def/bdr-pr/sm/>
+PREFIX smrr: <https://linked.data.gov.au/dataset/bdr/smrr/>
 
 []
     a sm:SubmissionManifest ;

--- a/validators/dr.ttl
+++ b/validators/dr.ttl
@@ -6,7 +6,7 @@ PREFIX schema: <https://schema.org/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX sm: <https://linked.data.gov.au/def/bdr-pr/sm/>
-PREFIX smrr: <https://linked.data.gov.au/def/bdr-pr/smrr/>
+PREFIX smrr: <https://linked.data.gov.au/dataset/bdr/smrr/>
 PREFIX tern: <https://w3id.org/tern/ontologies/tern/>
 PREFIX time: <http://www.w3.org/2006/time#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/validators/proj.ttl
+++ b/validators/proj.ttl
@@ -1,4 +1,4 @@
-PREFIX : <https://linked.data.gov.au/def/bdr-pr/dr/validator/>
+PREFIX : <https://linked.data.gov.au/def/bdr-pr/proj/validator/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX schema: <https://schema.org/>

--- a/validators/sm.ttl
+++ b/validators/sm.ttl
@@ -66,7 +66,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:targetObjectsOf prof:hasRole ;
     sh:property [
         sh:path skos:inScheme ;
-        sh:value <https://linked.data.gov.au/def/bdr-proj/smrr> ;
+        sh:value <https://linked.data.gov.au/dataset/bdr/smrr> ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:message "Each role indicated for a Resource Descriptor a member of the Submission Manifest Model Resource Roles Vocabulary, indicated with the skos:inScheme predicate for the role Concept" ;

--- a/vocabs/smrr.ttl
+++ b/vocabs/smrr.ttl
@@ -1,5 +1,5 @@
-PREFIX : <https://linked.data.gov.au/def/bdr-proj/smrr/>
-PREFIX cs: <https://linked.data.gov.au/def/bdr-proj/smrr>
+PREFIX : <https://linked.data.gov.au/dataset/bdr/smrr/>
+PREFIX cs: <https://linked.data.gov.au/dataset/bdr/smrr>
 PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>


### PR DESCRIPTION
* Fix vocab IRI for SMRR  to match BDR usage.
* Fix erroneous BDR Projects Model IRIS, replace  /bdr-proj/ usages for /bdr-pr/proj/