### PR TITLE
Declare BDR submission role vocabulary resource

### DIFF
--- a/profile.ttl
+++ b/profile.ttl
@@ -12,12 +12,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     
 This profile has been created to add additional constraints to the use of ABIS in the form of additional models that must be used to define data management aspects of data destined for absorbtion into the Biodiversity Data Repository, BDR.""" ;
     schema:dateCreated "2025-03-31"^^xsd:date ;
-    schema:dateModified "2025-03-31"^^xsd:date ;
+    schema:dateModified "2026-08-10"^^xsd:date ;
     schema:dateIssued "2025-03-31"^^xsd:date ;
     schema:creator <https://linked.data.gov.au/org/dcceew> ;
     schema:publisher <https://linked.data.gov.au/org/dcceew> ;
     schema:license <http://purl.org/NET/rdflicense/cc-by4.0> ;
     schema:copyrightNotice "(c) Department of Climate Change, Energy, the Environment and Water, 2025" ;
+    prof:hasResource <https://linked.data.gov.au/def/bdr-pr/vocabularies/submission-manifest-resource-roles> ;
     prof:isProfileOf <https://linked.data.gov.au/def/abis> ;
 .
 
@@ -52,5 +53,13 @@ This profile has been created to add additional constraints to the use of ABIS i
     schema:name "JSON-LD Context" ;
     dcterms:format "application/ld+json" ;
     prof:hasArtifact "https://linked.data.gov.au/def/bdr-pr/context.json"^^xsd:anyURI ;
+    prof:hasRole role:vocabulary ;
+.
+
+<https://linked.data.gov.au/def/bdr-pr/vocabularies/submission-manifest-resource-roles>
+    a prof:ResourceDescriptor ;
+    schema:name "BDR Submission Manifest Resource Roles vocabulary"@en ;
+    dcterms:format "text/turtle" ;
+    prof:hasArtifact "https://linked.data.gov.au/dataset/bdr/smrr"^^xsd:anyURI ;
     prof:hasRole role:vocabulary ;
 .


### PR DESCRIPTION
## Summary

- declare the BDR Submission Manifest Resource Roles vocabulary as a direct BDR Profile `prof:ResourceDescriptor`
- link the resource from the machine-readable BDR Profile
- retain ABIS vocabulary resources through `prof:isProfileOf` rather than duplicating them
- update the profile modification date

## Evidence

The BDR Submission Manifest specification requires SMRR concepts and the SHACL validator fixes `skos:inScheme` to `https://linked.data.gov.au/dataset/bdr/smrr`. Production-observed usage alone was not used as a basis for adding other vocabulary resources.

The inherited ABIS vocabulary declaration is proposed separately in `AusBIGG/abis`.

## Validation

- parsed the changed Turtle with Kurra 3.0.4
- queried the graph with Kurra to confirm the direct SMRR resource
- verified that the BDR Profile inherits ABIS without directly duplicating the TERN vocabulary
- `git diff --check`

Closes dcceew-bdr/bdr-ops#165
